### PR TITLE
#163804420 Users should be able to view the available menu

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import NavBar from './components/layout/NavBar';
 import Footer from './components/layout/Footer';
 import Landing from './components/layout/Landing';
 import Register from './components/auth/Register';
+import Menu from './components/menu/menu';
 import Login from './components/auth/Login';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -27,6 +28,7 @@ export class App extends Component {
             <Route exact path="/" component={Landing} />
             <Route exact path="/register" component={Register} />
             <Route exact path="/login" component={Login} />
+            <Route exact path="/menu" component={Menu} />
           </Switch>
           <Footer />
         </div>

--- a/src/__tests__/actions/authActions.tests.js
+++ b/src/__tests__/actions/authActions.tests.js
@@ -1,5 +1,6 @@
+/* eslint-disable jest/no-identical-title */
 /* eslint-disable jest/valid-expect-in-promise */
-import { registerUser } from '../../actions/authActions';
+import { registerUser} from '../../actions/authActions';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
@@ -10,7 +11,7 @@ const mockStore = configureMockStore(middlewares);
 
 
 describe('registerUser() action', () => {
-  afterEach(() => fetchMock.restore());
+afterEach(() => fetchMock.restore());
 
   it('returns errors given incorrect data', () => {
     const API_HOST_URL = process.env.API_URL;
@@ -32,7 +33,7 @@ describe('registerUser() action', () => {
     const store = mockStore();
     const expectedActions = [
       {
-       
+      
         payload: {
           
             message: 'The username should only contain alphabetic characters'

--- a/src/__tests__/actions/menuAction.test.js
+++ b/src/__tests__/actions/menuAction.test.js
@@ -1,0 +1,31 @@
+import Enzyme from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import EnzymeAdapter from 'enzyme-adapter-react-16';
+import thunk from 'redux-thunk';
+import fetchMock from 'fetch-mock';
+import { getMenu } from '../../actions/menuAction';
+
+Enzyme.configure({ adapter: new EnzymeAdapter() });
+const middleware = [thunk];
+const mockStore = configureMockStore(middleware);
+const API_HOST_URL = process.env.API_URL;
+
+
+it.only('test Menu action', () => {
+  const url = `${API_HOST_URL}/menu`;
+  fetchMock.getOnce(url,{ 
+    "menu": []
+   
+  });
+  const expectedActions = [
+    {
+      payload: { menu: [] },
+      type: 'GET_MENU'
+    }
+  ];
+  const store = mockStore();
+
+  return store
+    .dispatch(getMenu())
+    .then(() => expect(store.getActions()).toEqual(expectedActions));
+});

--- a/src/__tests__/components/menu/Menu.test.js
+++ b/src/__tests__/components/menu/Menu.test.js
@@ -1,0 +1,17 @@
+import Enzyme from 'enzyme';
+import EnzymeAdapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import { shallow} from 'enzyme';
+
+
+Enzyme.configure({ adapter: new EnzymeAdapter() });
+
+it('test rendering all menu', () => {
+  const props = {
+    getMenu: () => jest.fn(),
+    articles: []
+  };
+  const wrapper = shallow(<menu {...props} />);
+  expect(wrapper).toMatchSnapshot();
+});
+

--- a/src/__tests__/components/menu/__snapshots__/Menu.test.js.snap
+++ b/src/__tests__/components/menu/__snapshots__/Menu.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test rendering all menu 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <menu
+    articles={Array []}
+    getMenu={[Function]}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "articles": Array [],
+      "getMenu": [Function],
+    },
+    "ref": null,
+    "rendered": null,
+    "type": "menu",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "articles": Array [],
+        "getMenu": [Function],
+      },
+      "ref": null,
+      "rendered": null,
+      "type": "menu",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/actions/menuAction.js
+++ b/src/actions/menuAction.js
@@ -1,0 +1,26 @@
+import { GET_MENU } from '../constants/ActionTypes';
+
+
+const API_HOST_URL = process.env.API_URL;
+const token = window.localStorage.getItem('access_token');
+export const getMenu = (url = undefined) => dispatch => {
+
+    let path = url;
+    if (!path) {
+      path = `${API_HOST_URL}/menu`;
+    }
+    return fetch(path, {
+      method: 'GET',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `${token}`
+      }
+    })
+      .then(res => res.json())
+      .then(menu => {
+        dispatch({
+          type: GET_MENU,
+          payload: menu
+        });
+      });
+  };

--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -1,0 +1,74 @@
+/* eslint-disable react/jsx-key */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { getMenu } from '../../actions/menuAction';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+
+
+const API_HOST_URL = process.env.API_URL;
+
+export class Menu extends Component {
+  constructor(props) {
+    super(props);
+  }
+  
+  componentDidMount() {
+    this.props.getMenu(`${API_HOST_URL}/menu`);
+  }
+
+
+  render() {
+    const postItem = this.props.menu.menu.map(post => (
+      <section id="dashboard-page" className="flex-grow-1">
+        <section className="mt-5 mb-2">
+          <div className="container">
+            <div className="row">
+              <div className="col-md-10 m-auto">
+                <div className="card mb-3">
+                  <div className="card-body">
+                    
+                    <h5 className="card-title">Food:&nbsp;  {post.item_name}</h5>
+                    <h5 className="card-text">Price:&nbsp;  {post.price}/=</h5>
+                    <Link to="/order">
+                    <button
+                        onClick={this.Order}
+                        type="button"
+                        className="btn btn-warning mr-1"
+                      >
+                        <i className="fas fa-utensils"></i>
+                    </button>
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </section>
+    ));
+    return (
+      <div>
+        {postItem}
+        <div className="container d-flex flex-row justify-content-end mb-3">
+        </div>
+      </div>
+    );
+  }
+}
+
+Menu.propTypes = {
+  menu: PropTypes.object.isRequired
+};
+
+const mapStateToProps = state => {
+  return {
+    menu: state.menu,
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  { getMenu: getMenu }
+)(Menu);

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -1,4 +1,6 @@
 export const GET_MENU = 'GET_MENU';
+export const GET_SINGLE_MENU  = 'GET_SINGLE_MENU';
 export const GET_ERRORS = 'GET_ERRORS';
 export const SIGNOUT = 'SIGNOUT';
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
+export const GET_MY_ORDERS = 'GET_MY_ORDERS';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,12 +2,14 @@ import { combineReducers } from 'redux';
 import authReducer from './authReducer';
 import errorReducer from './errorReducer';
 import { currentUser } from '../reducers/authReducer';
+import menuReducer from '../reducers/menuReducer';
 import sampleReducer from './sampleReducer';
 
 const rootReducer = combineReducers({
   auth: authReducer,
   users: sampleReducer,
   errors: errorReducer,
+  menu: menuReducer,
   currentUser
 });
 

--- a/src/reducers/menuReducer.js
+++ b/src/reducers/menuReducer.js
@@ -1,0 +1,26 @@
+import { GET_MENU, GET_SINGLE_MENU } from '../constants/ActionTypes';
+  
+  const initialState = {
+    menu: [],
+    errors: {},
+    
+  };
+  
+  const menuReducer = (state = initialState, action) => {
+    switch (action.type) {
+      case GET_MENU:
+        return {
+          ...state,
+          menu: action.payload,
+        };
+      case GET_SINGLE_MENU:
+        return {
+          ...state,
+          menu: action.payload
+        };
+      default:
+        return state;
+    }
+  };
+  export default menuReducer;
+  


### PR DESCRIPTION
### What does this PR do?
- This Pull Request enables users to view the available menu

#### Description of Task to be completed?
- When a users login in, they should be able to view the available menu

#### How should this be manually tested?
- Clone the repository.
- Run `yarn'
- Run `yarn start'
- Run the login route in the browser `http://localhost:3000/menu`

#### What are the relevant pivotal tracker stories?
[#163804420](https://www.pivotaltracker.com/story/show/163804420)

<img width="705" alt="screen shot 2019-02-09 at 17 16 09" src="https://user-images.githubusercontent.com/31479458/52521838-71ef5800-2c8e-11e9-835f-5ee2ebe57fc7.png">
